### PR TITLE
Update action for entities

### DIFF
--- a/features/project/update.feature
+++ b/features/project/update.feature
@@ -1,0 +1,13 @@
+Feature: Update
+  In order to be able to have projects
+  As a developer
+  I want to update projects
+
+  @kalibro_processor_restart
+  Scenario: Setting and resetting the name of a valid project (ensures that update is getting called instead of create)
+    Given I have a project with name "Kalibro"
+    And I set the project name to "QtCalculator"
+    And I save the given project
+    And I set the project name to "Kalibro"
+    And I save the given project
+    Then I should get true as the response

--- a/features/step_definitions/project_steps.rb
+++ b/features/step_definitions/project_steps.rb
@@ -10,6 +10,10 @@ Given(/^I have a project with name "(.*?)"$/) do |name|
   @project = FactoryGirl.create(:project, {name: name})
 end
 
+Given(/^I set the project name to "(.*?)"$/) do |name|
+  @project.name = name
+end
+
 When(/^I save the project$/) do
   @project.save
 end
@@ -31,6 +35,10 @@ When(/^I ask for all the projects$/) do
   @all_projects = KalibroClient::Entities::Processor::Project.all
 end
 
+When(/^I save the given project$/) do
+  @response = @project.save
+end
+
 Then(/^the project should exist$/) do
   expect(KalibroClient::Entities::Processor::Project.exists?(@project.id)).to be_truthy
 end
@@ -45,4 +53,8 @@ end
 
 Then(/^I should get a list with the given project$/) do
   expect(@all_projects).to include(@project)
+end
+
+Then(/^I should get true as the response$/) do
+  expect(@response).to be_truthy
 end

--- a/lib/kalibro_client/entities/base.rb
+++ b/lib/kalibro_client/entities/base.rb
@@ -21,17 +21,19 @@ require 'kalibro_client/helpers/request_methods'
 module KalibroClient
   module Entities
     class Base
-      attr_accessor :kalibro_errors
+      attr_accessor :kalibro_errors, :persisted
 
       def initialize(attributes={})
         attributes.each { |field, value| send("#{field}=", value) if self.class.is_valid?(field) }
         @kalibro_errors = []
+        @persisted = false
       end
 
       def to_hash(options={})
         hash = Hash.new
         excepts = options[:except].nil? ? [] : options[:except]
         excepts << "kalibro_errors"
+        excepts << "persisted"
         fields.each do |field|
           hash = field_to_hash(field).merge(hash) if !excepts.include?(field)
         end
@@ -61,21 +63,26 @@ module KalibroClient
       end
 
       def save
-        begin
-          response = self.class.request(save_action, save_params, :post, save_prefix)
+        if persisted?
+          self.update
+        else
+          begin
+            response = self.class.request(save_action, save_params, :post, save_prefix)
 
-          if response["errors"].nil?
-            self.id = response[instance_class_name]["id"]
-            self.created_at = response[instance_class_name]["created_at"] unless response[instance_class_name]["created_at"].nil?
-            self.updated_at = response[instance_class_name]["updated_at"] unless response[instance_class_name]["updated_at"].nil?
-            true
-          else
-            self.kalibro_errors = response["errors"]
+            if response["errors"].nil?
+              self.id = response[instance_class_name]["id"]
+              self.created_at = response[instance_class_name]["created_at"] unless response[instance_class_name]["created_at"].nil?
+              self.updated_at = response[instance_class_name]["updated_at"] unless response[instance_class_name]["updated_at"].nil?
+              @persisted = true
+              true
+            else
+              self.kalibro_errors = response["errors"]
+              false
+            end
+          rescue Exception => exception
+            add_error exception
             false
           end
-        rescue Exception => exception
-          add_error exception
-          false
         end
       end
 
@@ -87,6 +94,16 @@ module KalibroClient
         new_model = new attributes
         new_model.save
         new_model
+      end
+
+      def update
+        response = self.class.request(update_action, update_params, :put, "")
+        unless response["errors"].nil?
+          response["errors"].each { |error| add_error(error) }
+          false
+        else
+          true
+        end
       end
 
       def ==(another)
@@ -119,8 +136,18 @@ module KalibroClient
 
       def destroy
         begin
-          self.class.request(destroy_action, destroy_params, :delete, destroy_prefix)
-          self.kalibro_errors.empty? ? true : false
+          response = self.class.request(destroy_action, destroy_params, :delete, destroy_prefix)
+
+          unless response['errors'].nil?
+            response['errors'].each { |error| add_error(error) }
+          end
+
+          if self.kalibro_errors.empty?
+            @persisted = false
+            true
+          else
+            false
+          end
         rescue Exception => exception
           add_error exception
           false
@@ -136,6 +163,8 @@ module KalibroClient
         response = [response] if response.is_a?(Hash)
         response
       end
+
+      alias_method :persisted?, :persisted
 
       protected
 

--- a/lib/kalibro_client/entities/processor/metric_result.rb
+++ b/lib/kalibro_client/entities/processor/metric_result.rb
@@ -21,7 +21,7 @@ module KalibroClient
 
         attr_accessor :id, :value, :aggregated_value, :module_result_id, :metric_configuration_id
 
-        def initialize(attributes={})
+        def initialize(attributes={}, persisted=false)
           value = attributes["value"]
           @value = (value == "NaN") ? attributes["aggregated_value"].to_f : value.to_f
           attributes.each do |field, value|
@@ -30,6 +30,7 @@ module KalibroClient
             end
           end
           @kalibro_errors = []
+          @persisted = persisted
         end
 
         def id=(value)

--- a/lib/kalibro_client/helpers/request_methods.rb
+++ b/lib/kalibro_client/helpers/request_methods.rb
@@ -30,6 +30,7 @@ module RequestMethods
   def destroy_action
     ":id"
   end
+  alias_method :update_action, :destroy_action
 
   def destroy_params
     {id: self.id}
@@ -37,6 +38,10 @@ module RequestMethods
 
   def destroy_prefix
     ""
+  end
+
+  def update_params
+    {instance_class_name.underscore.to_sym => self.to_hash, :id => self.id}
   end
 
   module ClassMethods


### PR DESCRIPTION
This action is necessary so the edit pages on Prezento works properly.

With this the Project edition on Prezento should stop to always try to create and properly update the objects.