### PR TITLE
Process by branch

### DIFF
--- a/lib/kalibro_client/entities/processor/repository.rb
+++ b/lib/kalibro_client/entities/processor/repository.rb
@@ -19,7 +19,7 @@ module KalibroClient
     module Processor
       class Repository < KalibroClient::Entities::Processor::Base
 
-        attr_accessor :id, :name, :description, :license, :period, :scm_type, :address, :kalibro_configuration_id, :project_id, :send_email, :code_directory
+        attr_accessor :id, :name, :description, :license, :period, :scm_type, :address, :kalibro_configuration_id, :project_id, :send_email, :code_directory, :branch
 
         def self.repository_types
           request('types', {}, :get)['types'].to_a

--- a/lib/kalibro_client/entities/processor/repository.rb
+++ b/lib/kalibro_client/entities/processor/repository.rb
@@ -123,6 +123,10 @@ module KalibroClient
           return repositories
         end
 
+        def self.branches(url, scm_type)
+          request("/branches", {url: url, scm_type: scm_type})
+        end
+
         private
 
         def save_params

--- a/spec/entities/processor/repository_spec.rb
+++ b/spec/entities/processor/repository_spec.rb
@@ -386,5 +386,39 @@ describe KalibroClient::Entities::Processor::Repository do
         expect(response.state).to eq(processing.state)
       end
     end
+
+    describe 'branches' do
+      let(:branches) { ['branch1', 'branch2'] }
+      let(:url) { 'dummy-url' }
+      let(:scm_type) { 'GIT' }
+
+      context 'valid parameters' do
+        before :each do
+          KalibroClient::Entities::Processor::Repository.
+            expects(:request).
+            with("/branches", {url: url, scm_type: scm_type}).
+            returns({'branches' => branches})
+        end
+
+        it 'is expected to return an array of branch names' do
+          response = subject.class.branches(url, scm_type)
+          expect(response).to eq('branches' => branches)
+        end
+      end
+
+      context 'invalid parameters' do
+        before :each do
+          KalibroClient::Entities::Processor::Repository.
+            expects(:request).
+            with("/branches", {url: url, scm_type: scm_type}).
+            returns({'errors' => ['Error']})
+        end
+
+        it 'is expected to return an array of branch names' do
+          response = subject.class.branches(url, scm_type)
+          expect(response).to eq('errors' => ['Error'])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Included method to access the branches' feature of Repository on Kalibro Processor.

It depends on the SCM type and the address of the repository. It may return a list of the existing branches or an error message.