### PR TITLE
All repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
   postgresql: "9.3"
 
 before_script:
-  - git clone https://github.com/mezuro/kalibro_install.git -b v2.5 kalibro_install
+  - git clone https://github.com/mezuro/kalibro_install.git -b v2.6 kalibro_install
   - pushd kalibro_install
     # Remove bugged libzmq3 package, see https://github.com/travis-ci/travis-ci/issues/982 and https://github.com/travis-ci/travis-ci/issues/1715 for details
   - sudo apt-get remove libzmq3

--- a/features/repository/all.feature
+++ b/features/repository/all.feature
@@ -3,7 +3,7 @@ Feature: Repositories listing
   As a developer
   I want to see all the repositories on the service
 
-  @kalibro_processor_restart @kalibro_configuration_restart
+  @kalibro_processor_restart @kalibro_configuration_restart @wip
   Scenario: With existing project repository
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Java"

--- a/features/repository/all.feature
+++ b/features/repository/all.feature
@@ -3,12 +3,13 @@ Feature: Repositories listing
   As a developer
   I want to see all the repositories on the service
 
-  @kalibro_processor_restart @kalibro_configuration_restart @wip
+  @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With existing project repository
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Java"
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+    And I have an independent repository
     When I ask for all the repositories
-    Then the response should contain the given repository
+    Then the response should contain the given repositories

--- a/features/step_definitions/repository_steps.rb
+++ b/features/step_definitions/repository_steps.rb
@@ -1,4 +1,6 @@
-
+Given(/^I have an independent repository$/) do
+  @independent_repository = FactoryGirl.create(:repository, project_id: nil)
+end
 
 Given(/^the given project has the following Repositories:$/) do |table|
   hash = table.hashes.first
@@ -59,8 +61,9 @@ Then(/^I should get the given repository$/) do
   expect(@response).to eq(@repository)
 end
 
-Then(/^the response should contain the given repository$/) do
-  expect(@response.first.project_id).to eq(@project.id)
+Then(/^the response should contain the given repositories$/) do
+  expect(@response).to include(@repository)
+  expect(@response).to include(@independent_repository)
 end
 
 Then(/^the repositories should contain the project id$/) do

--- a/lib/kalibro_client/entities/processor/repository.rb
+++ b/lib/kalibro_client/entities/processor/repository.rb
@@ -19,7 +19,7 @@ module KalibroClient
     module Processor
       class Repository < KalibroClient::Entities::Processor::Base
 
-        attr_accessor :id, :name, :description, :license, :period, :scm_type, :address, :kalibro_configuration_id, :project_id, :send_email, :code_directory, :branch
+        attr_accessor :id, :name, :description, :license, :period, :scm_type, :address, :kalibro_configuration_id, :project_id, :code_directory, :branch
 
         def self.repository_types
           request('types', {}, :get)['types'].to_a

--- a/lib/kalibro_client/entities/processor/repository.rb
+++ b/lib/kalibro_client/entities/processor/repository.rb
@@ -113,14 +113,7 @@ module KalibroClient
         end
 
         def self.all
-          projects = Project.all
-          repositories = []
-
-          projects.each do |project|
-            repositories.concat(repositories_of(project.id))
-          end
-
-          return repositories
+          request("", {}, :get)['repositories']
         end
 
         def self.branches(url, scm_type)

--- a/lib/kalibro_client/entities/processor/repository.rb
+++ b/lib/kalibro_client/entities/processor/repository.rb
@@ -113,7 +113,7 @@ module KalibroClient
         end
 
         def self.all
-          request("", {}, :get)['repositories']
+          create_objects_array_from_hash(request("", {}, :get))
         end
 
         def self.branches(url, scm_type)

--- a/spec/entities/base_spec.rb
+++ b/spec/entities/base_spec.rb
@@ -356,7 +356,7 @@ describe KalibroClient::Entities::Base do
   describe 'create_objects_array_from_hash' do
     context 'with nil' do
       it 'should return an empty array' do
-        expect(KalibroClient::Entities::Base.create_objects_array_from_hash("bases" => nil)).to eq([])
+        expect(KalibroClient::Entities::Base.create_objects_array_from_hash("bases" => [])).to eq([])
       end
     end
 

--- a/spec/entities/configurations/kalibro_configuration_spec.rb
+++ b/spec/entities/configurations/kalibro_configuration_spec.rb
@@ -30,7 +30,7 @@ describe KalibroClient::Entities::Configurations::KalibroConfiguration do
         KalibroClient::Entities::Configurations::KalibroConfiguration.
           expects(:request).
           with('', {}, :get).
-          returns({'kalibro_configurations' => nil})
+          returns({'kalibro_configurations' => []})
       end
 
       it 'should return nil' do

--- a/spec/entities/configurations/kalibro_range_spec.rb
+++ b/spec/entities/configurations/kalibro_range_spec.rb
@@ -76,7 +76,7 @@ describe KalibroClient::Entities::Configurations::KalibroRange do
         KalibroClient::Entities::Configurations::KalibroRange.
           expects(:request).
           with('', {}, :get, "metric_configurations/#{metric_configuration.id}").
-          returns({'ranges' => nil})
+          returns({'ranges' => []})
       end
 
       it 'should return a list with the ranges' do

--- a/spec/entities/configurations/reading_group_spec.rb
+++ b/spec/entities/configurations/reading_group_spec.rb
@@ -32,7 +32,7 @@ describe KalibroClient::Entities::Configurations::ReadingGroup do
         KalibroClient::Entities::Configurations::ReadingGroup.
           expects(:request).
           with('', {}, :get).
-          returns({'reading_groups' => nil})
+          returns({'reading_groups' => []})
       end
 
       it 'should return nil' do

--- a/spec/entities/processor/metric_collector_details_spec.rb
+++ b/spec/entities/processor/metric_collector_details_spec.rb
@@ -23,7 +23,7 @@ describe KalibroClient::Entities::Processor::MetricCollectorDetails do
         KalibroClient::Entities::Processor::MetricCollectorDetails.
           expects(:request).
           with(:names, {}, :get).
-          returns({'names' => nil}.to_json)
+          returns({'names' => []})
       end
 
       it 'should return empty array' do
@@ -58,7 +58,7 @@ describe KalibroClient::Entities::Processor::MetricCollectorDetails do
         KalibroClient::Entities::Processor::MetricCollectorDetails.
           expects(:request).
           with('', {}, :get).
-          returns({"metric_collector_details" => nil})
+          returns({"metric_collector_details" => []})
       end
 
       it 'should return empty array' do

--- a/spec/entities/processor/project_spec.rb
+++ b/spec/entities/processor/project_spec.rb
@@ -5,7 +5,7 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -37,7 +37,7 @@ describe KalibroClient::Entities::Processor::Project do
         KalibroClient::Entities::Processor::Project.
           expects(:request).
           with('', {}, :get).
-          returns({"projects" => nil})
+          returns({"projects" => []})
       end
 
       it 'should return nil' do

--- a/spec/entities/processor/repository_spec.rb
+++ b/spec/entities/processor/repository_spec.rb
@@ -100,16 +100,11 @@ describe KalibroClient::Entities::Processor::Repository do
   end
 
   describe 'all' do
-    let(:project) { FactoryGirl.build(:project) }
-
     before :each do
-      KalibroClient::Entities::Processor::Project.
-        expects(:all).
-        returns([project])
       KalibroClient::Entities::Processor::Repository.
-        expects(:repositories_of).
-        with(project.id).
-        returns([subject])
+        expects(:request).
+        with("", {}, :get).
+        returns({'repositories' => [subject]})
     end
 
     it 'should list all the repositories' do

--- a/spec/entities/processor/repository_spec.rb
+++ b/spec/entities/processor/repository_spec.rb
@@ -104,7 +104,7 @@ describe KalibroClient::Entities::Processor::Repository do
       KalibroClient::Entities::Processor::Repository.
         expects(:request).
         with("", {}, :get).
-        returns({'repositories' => [subject]})
+        returns({'repositories' => [subject.to_hash]})
     end
 
     it 'should list all the repositories' do

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -24,7 +24,8 @@ FactoryGirl.define do
     address "svn://svn.code.sf.net/p/qt-calculator/code/trunk"
     kalibro_configuration_id 1
     project_id 1
-    send_email "test@test.com"
+    branch "master"
+    code_directory nil
 
     trait :with_id do
       id 1


### PR DESCRIPTION
Refactored repository's all method to use the index route provided by KalibroProcessor.

Before, we had to search for all the projects and iterate on them to end up with a list of all created repositories.
But now repositories don't have to be associated with projects, meaning some repositories would be left out if we used the previous implementation.
This modification will probably speed things up, since we are decreasing the number of requests.

Also, the corresponding acceptance test was refactored. It now creates a repository associated with a project and other one project independent. The change made on the expectations exposed an unused attribute (`send_email`) and attributes missing on the factory (`code_directory` and `branch`).

Finally, some unit tests were refactored to match the correct response of KalibroProcessor. We were mocking the requests with return `nil` return values but KalibroProcessor responds with an empty array on those cases.