### PR TITLE
Made Entities::Base#save! raise an exception on error

### DIFF
--- a/lib/kalibro_client/entities/base.rb
+++ b/lib/kalibro_client/entities/base.rb
@@ -87,7 +87,8 @@ module KalibroClient
       end
 
       def save!
-        save
+        return true if save
+        raise KalibroClient::Errors::RecordInvalid.new(self)
       end
 
       def self.create(attributes={})

--- a/lib/kalibro_client/errors.rb
+++ b/lib/kalibro_client/errors.rb
@@ -5,7 +5,7 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -16,3 +16,4 @@
 
 require 'kalibro_client/errors/standard'
 require 'kalibro_client/errors/record_not_found'
+require 'kalibro_client/errors/record_invalid'

--- a/lib/kalibro_client/errors/record_invalid.rb
+++ b/lib/kalibro_client/errors/record_invalid.rb
@@ -1,0 +1,19 @@
+module KalibroClient
+  module Errors
+    class RecordInvalid < Standard
+      attr_reader :record
+
+      def initialize(record = nil)
+        message = if record
+          @record = record
+          errors = @record.kalibro_errors.join(', ')
+          "Record invalid: #{errors}"
+        else
+          'Record invalid'
+        end
+
+        super(message)
+      end
+    end
+  end
+end

--- a/spec/entities/base_spec.rb
+++ b/spec/entities/base_spec.rb
@@ -210,9 +210,20 @@ describe KalibroClient::Entities::Base do
   describe 'save!' do
     subject { FactoryGirl.build(:project) }
 
-    it 'should call save' do
-      subject.expects(:save)
-      subject.save!
+    it 'should call save and not raise when saving works' do
+      subject.expects(:save).returns(true)
+      expect { subject.save! }.not_to raise_error
+    end
+
+    it 'should call save and raise RecordInvalid when saving fails' do
+      subject.expects(:kalibro_errors).returns(['test1', 'test2'])
+      subject.expects(:save).returns(false)
+
+      expect { subject.save! }.to raise_error { |error|
+        expect(error).to be_a(KalibroClient::Errors::RecordInvalid)
+        expect(error.record).to be(subject)
+        expect(error.message).to eq('Record invalid: test1, test2')
+      }
     end
   end
 


### PR DESCRIPTION
That matches the ActiveRecord API as excepted and avoids silent failures

Fixes #75