### PR TITLE
Metric configuration retrieval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ rvm:
 addons:
   postgresql: "9.3"
 
-before_script: 
+before_script:
   # Remove bugged libzmq3 package, see https://github.com/travis-ci/travis-ci/issues/982 and https://github.com/travis-ci/travis-ci/issues/1715 for details
   - sudo apt-get remove libzmq3
   - git clone https://github.com/mezuro/kalibro_install.git -b v3.8 kalibro_install
-  - KALIBRO_PROCESSOR_VERSION='v1.0.0' KALIBRO_CONFIGURATIONS_VERSION='v1.1.1' ./kalibro_install/install.sh
+  - KALIBRO_PROCESSOR_VERSION='v1.0.0' KALIBRO_CONFIGURATIONS_VERSION='v1.2.0' ./kalibro_install/install.sh
   - cp features/support/kalibro_cucumber_helpers.yml.sample features/support/kalibro_cucumber_helpers.yml
   - export BUNDLE_GEMFILE=$PWD/Gemfile
   - export CODECLIMATE_REPO_TOKEN=46cbb96b053b03ad66b0355bd96d0787f56fc5a4fc171b8d6eb30c421c5e6777

--- a/features/kalibro_configuration/hotspot_metric_configurations.feature
+++ b/features/kalibro_configuration/hotspot_metric_configurations.feature
@@ -1,0 +1,12 @@
+Feature: HotspotMetricConfiguration retrieval
+  In order to be able to list just with the HotspotMetricConfigurations
+  As a developer
+  I want to get all HotspotMetricConfigurations of a given KalibroConfiguration
+
+  @kalibro_configuration_restart @wip
+  Scenario: get a list of all metric configurations of some kalibro configuration
+    Given I have a kalibro configuration with name "Kalibro for Java"
+    And I have a reading group with name "Group"
+    And I have a hotspot metric configuration within the given kalibro configuration
+    When I request for hotspot_metric_configurations of the given kalibro configuration
+    Then I should get a list with the given HotspotMetricConfiguration

--- a/features/kalibro_configuration/hotspot_metric_configurations.feature
+++ b/features/kalibro_configuration/hotspot_metric_configurations.feature
@@ -4,7 +4,7 @@ Feature: HotspotMetricConfiguration retrieval
   I want to get all HotspotMetricConfigurations of a given KalibroConfiguration
 
   @kalibro_configuration_restart
-  Scenario: get a list of all metric configurations of some kalibro configuration
+  Scenario: get a list of all hotspot metric configurations of some kalibro configuration
     Given I have a kalibro configuration with name "Kalibro for Java"
     And I have a reading group with name "Group"
     And I have a hotspot metric configuration within the given kalibro configuration

--- a/features/kalibro_configuration/hotspot_metric_configurations.feature
+++ b/features/kalibro_configuration/hotspot_metric_configurations.feature
@@ -6,7 +6,6 @@ Feature: HotspotMetricConfiguration retrieval
   @kalibro_configuration_restart
   Scenario: get a list of all hotspot metric configurations of some kalibro configuration
     Given I have a kalibro configuration with name "Kalibro for Java"
-    And I have a reading group with name "Group"
     And I have a hotspot metric configuration within the given kalibro configuration
     When I request for hotspot_metric_configurations of the given kalibro configuration
     Then I should get a list with the given HotspotMetricConfiguration

--- a/features/kalibro_configuration/hotspot_metric_configurations.feature
+++ b/features/kalibro_configuration/hotspot_metric_configurations.feature
@@ -3,7 +3,7 @@ Feature: HotspotMetricConfiguration retrieval
   As a developer
   I want to get all HotspotMetricConfigurations of a given KalibroConfiguration
 
-  @kalibro_configuration_restart @wip
+  @kalibro_configuration_restart
   Scenario: get a list of all metric configurations of some kalibro configuration
     Given I have a kalibro configuration with name "Kalibro for Java"
     And I have a reading group with name "Group"

--- a/features/kalibro_configuration/tree_metric_configurations.feature
+++ b/features/kalibro_configuration/tree_metric_configurations.feature
@@ -1,0 +1,12 @@
+Feature: TreeMetricConfiguration retrieval
+  In order to be able to list just with the TreeMetricConfigurations
+  As a developer
+  I want to get all TreeMetricConfigurations of a given KalibroConfiguration
+
+  @kalibro_configuration_restart @wip
+  Scenario: get a list of all metric configurations of some kalibro configuration
+    Given I have a kalibro configuration with name "Kalibro for Java"
+    And I have a reading group with name "Group"
+    And I have a tree metric configuration within the given kalibro configuration
+    When I request for tree_metric_configurations of the given kalibro configuration
+    Then I should get a list with the given TreeMetricConfiguration

--- a/features/kalibro_configuration/tree_metric_configurations.feature
+++ b/features/kalibro_configuration/tree_metric_configurations.feature
@@ -4,7 +4,7 @@ Feature: TreeMetricConfiguration retrieval
   I want to get all TreeMetricConfigurations of a given KalibroConfiguration
 
   @kalibro_configuration_restart
-  Scenario: get a list of all metric configurations of some kalibro configuration
+  Scenario: get a list of all tree metric configurations of some kalibro configuration
     Given I have a kalibro configuration with name "Kalibro for Java"
     And I have a reading group with name "Group"
     And I have a tree metric configuration within the given kalibro configuration

--- a/features/kalibro_configuration/tree_metric_configurations.feature
+++ b/features/kalibro_configuration/tree_metric_configurations.feature
@@ -3,7 +3,7 @@ Feature: TreeMetricConfiguration retrieval
   As a developer
   I want to get all TreeMetricConfigurations of a given KalibroConfiguration
 
-  @kalibro_configuration_restart @wip
+  @kalibro_configuration_restart
   Scenario: get a list of all metric configurations of some kalibro configuration
     Given I have a kalibro configuration with name "Kalibro for Java"
     And I have a reading group with name "Group"

--- a/features/step_definitions/metric_configuration_steps.rb
+++ b/features/step_definitions/metric_configuration_steps.rb
@@ -18,6 +18,18 @@ Given(/^I have a loc configuration within the given kalibro configuration$/) do
                                               kalibro_configuration_id: @kalibro_configuration.id})
 end
 
+Given(/^I have a hotspot metric configuration within the given kalibro configuration$/) do
+  @hotspot_metric_configuration = FactoryGirl.create(:metric_configuration,
+                                                     {metric: FactoryGirl.build(:hotspot_metric),
+                                                      reading_group_id: @reading_group.id,
+                                                      kalibro_configuration_id: @kalibro_configuration.id})
+end
+
+Given(/^I have a tree metric configuration within the given kalibro configuration$/) do
+  step "I have a loc configuration within the given kalibro configuration"
+  @tree_metric_configuration = @metric_configuration
+end
+
 When(/^I search a metric configuration with the same id of the given metric configuration$/) do
   @found_metric_configuration = KalibroClient::Entities::Configurations::MetricConfiguration.find(@metric_configuration.id)
 end
@@ -49,6 +61,14 @@ When(/^I have a flay configuration within the given kalibro configuration$/) do
                                               kalibro_configuration_id: @kalibro_configuration.id})
 end
 
+When(/^I request for hotspot_metric_configurations of the given kalibro configuration$/) do
+  @hotspot_metric_configurations = @kalibro_configuration.hotspot_metric_configurations
+end
+
+When(/^I request for tree_metric_configurations of the given kalibro configuration$/) do
+  @tree_metric_configurations = @kalibro_configuration.tree_metric_configurations
+end
+
 Then(/^it should return the same metric configuration as the given one$/) do
   expect(@found_metric_configuration).to eq(@metric_configuration)
 end
@@ -72,4 +92,12 @@ end
 
 Then(/^its metric should be Hotspot one$/) do
   expect(@found_metric_configuration.metric).to be_a(KalibroClient::Entities::Miscellaneous::HotspotMetric)
+end
+
+Then(/^I should get a list with the given HotspotMetricConfiguration$/) do
+  expect(@hotspot_metric_configurations).to include(@hotspot_metric_configuration)
+end
+
+Then(/^I should get a list with the given TreeMetricConfiguration$/) do
+  expect(@tree_metric_configurations).to include(@tree_metric_configuration)
 end

--- a/features/step_definitions/metric_configuration_steps.rb
+++ b/features/step_definitions/metric_configuration_steps.rb
@@ -21,7 +21,6 @@ end
 Given(/^I have a hotspot metric configuration within the given kalibro configuration$/) do
   @hotspot_metric_configuration = FactoryGirl.create(:metric_configuration,
                                                      {metric: FactoryGirl.build(:hotspot_metric),
-                                                      reading_group_id: @reading_group.id,
                                                       kalibro_configuration_id: @kalibro_configuration.id})
 end
 

--- a/lib/kalibro_client/entities/configurations/kalibro_configuration.rb
+++ b/lib/kalibro_client/entities/configurations/kalibro_configuration.rb
@@ -31,6 +31,18 @@ module KalibroClient
         def metric_configurations
           KalibroClient::Entities::Configurations::MetricConfiguration.create_objects_array_from_hash(self.class.request(':id/metric_configurations', {id: id}, :get))
         end
+
+        def hotspot_metric_configurations
+          hotspot_metric_configurations_hash = self.class.request(':id/hotspot_metric_configurations', {id: id}, :get)
+          KalibroClient::Entities::Configurations::MetricConfiguration.create_objects_array_from_hash(
+            {'metric_configurations' => hotspot_metric_configurations_hash['hotspot_metric_configurations']})
+        end
+
+        def tree_metric_configurations
+          tree_metric_configurations_hash = self.class.request(':id/tree_metric_configurations', {id: id}, :get)
+          KalibroClient::Entities::Configurations::MetricConfiguration.create_objects_array_from_hash(
+            {'metric_configurations' => tree_metric_configurations_hash['tree_metric_configurations']})
+        end
       end
     end
   end

--- a/lib/kalibro_client/entities/configurations/kalibro_configuration.rb
+++ b/lib/kalibro_client/entities/configurations/kalibro_configuration.rb
@@ -29,7 +29,7 @@ module KalibroClient
         end
 
         def metric_configurations
-         KalibroClient::Entities::Configurations::MetricConfiguration.create_objects_array_from_hash(self.class.request(':id/metric_configurations', {id: id}, :get))
+          KalibroClient::Entities::Configurations::MetricConfiguration.create_objects_array_from_hash(self.class.request(':id/metric_configurations', {id: id}, :get))
         end
       end
     end

--- a/spec/entities/configurations/kalibro_configuration_spec.rb
+++ b/spec/entities/configurations/kalibro_configuration_spec.rb
@@ -33,7 +33,7 @@ describe KalibroClient::Entities::Configurations::KalibroConfiguration do
           returns({'kalibro_configurations' => []})
       end
 
-      it 'should return nil' do
+      it 'is expected to return nil' do
         expect(KalibroClient::Entities::Configurations::KalibroConfiguration.all).to be_empty
       end
     end
@@ -49,7 +49,7 @@ describe KalibroClient::Entities::Configurations::KalibroConfiguration do
           returns({'kalibro_configurations' => [kalibro_configuration.to_hash, another_kalibro_configuration.to_hash]})
       end
 
-      it 'should return the two elements' do
+      it 'is expected to return the two elements' do
         kalibro_configurations = KalibroClient::Entities::Configurations::KalibroConfiguration.all
 
         expect(kalibro_configurations.size).to eq(2)

--- a/spec/entities/configurations/kalibro_configuration_spec.rb
+++ b/spec/entities/configurations/kalibro_configuration_spec.rb
@@ -88,4 +88,66 @@ describe KalibroClient::Entities::Configurations::KalibroConfiguration do
       end
     end
   end
+
+  describe 'hotspot_metric_configuartions' do
+    context 'with no hotspot metric configurations' do
+      before :each do
+        KalibroClient::Entities::Configurations::KalibroConfiguration.
+          expects(:request).
+          with(':id/hotspot_metric_configurations', {id: subject.id}, :get).
+          returns({'hotspot_metric_configurations' => []})
+      end
+
+      it 'is expected to return an empty array' do
+        expect(subject.hotspot_metric_configurations).to be_empty
+      end
+    end
+
+    context 'with hotspot metric configurations' do
+      let(:metric_configuration_1) { FactoryGirl.build(:metric_configuration, kalibro_configuration_id: subject.id) }
+      let(:metric_configuration_2) { FactoryGirl.build(:metric_configuration, kalibro_configuration_id: subject.id) }
+
+      before :each do
+        KalibroClient::Entities::Configurations::KalibroConfiguration.
+          expects(:request).
+          with(':id/hotspot_metric_configurations', {id: subject.id}, :get).
+          returns({'hotspot_metric_configurations' => [metric_configuration_1.to_hash, metric_configuration_2.to_hash]})
+      end
+
+      it 'is expected to return an array with the hotspot metric configurations' do
+        expect(subject.hotspot_metric_configurations).to eq([metric_configuration_1, metric_configuration_2])
+      end
+    end
+  end
+
+  describe 'tree_metric_configuartions' do
+    context 'with no tree metric configurations' do
+      before :each do
+        KalibroClient::Entities::Configurations::KalibroConfiguration.
+          expects(:request).
+          with(':id/tree_metric_configurations', {id: subject.id}, :get).
+          returns({'tree_metric_configurations' => []})
+      end
+
+      it 'is expected to return an empty array' do
+        expect(subject.tree_metric_configurations).to be_empty
+      end
+    end
+
+    context 'with tree metric configurations' do
+      let(:metric_configuration_1) { FactoryGirl.build(:metric_configuration, kalibro_configuration_id: subject.id) }
+      let(:metric_configuration_2) { FactoryGirl.build(:metric_configuration, kalibro_configuration_id: subject.id) }
+
+      before :each do
+        KalibroClient::Entities::Configurations::KalibroConfiguration.
+          expects(:request).
+          with(':id/tree_metric_configurations', {id: subject.id}, :get).
+          returns({'tree_metric_configurations' => [metric_configuration_1.to_hash, metric_configuration_2.to_hash]})
+      end
+
+      it 'is expected to return an array with the tree metric configurations' do
+        expect(subject.tree_metric_configurations).to eq([metric_configuration_1, metric_configuration_2])
+      end
+    end
+  end
 end

--- a/spec/entities/configurations/kalibro_configuration_spec.rb
+++ b/spec/entities/configurations/kalibro_configuration_spec.rb
@@ -68,7 +68,7 @@ describe KalibroClient::Entities::Configurations::KalibroConfiguration do
           returns({'metric_configurations' => []})
       end
 
-      it 'should return an empty array' do
+      it 'is expected to return an empty array' do
         expect(subject.metric_configurations).to be_empty
       end
     end
@@ -83,7 +83,7 @@ describe KalibroClient::Entities::Configurations::KalibroConfiguration do
           returns({'metric_configurations' => [metric_configuration_1.to_hash, metric_configuration_2.to_hash]})
       end
 
-      it 'should return an empty array' do
+      it 'is expected to return an array with the given metric configurations' do
         expect(subject.metric_configurations).to eq([metric_configuration_1, metric_configuration_2])
       end
     end

--- a/spec/entities/configurations/kalibro_configuration_spec.rb
+++ b/spec/entities/configurations/kalibro_configuration_spec.rb
@@ -89,7 +89,7 @@ describe KalibroClient::Entities::Configurations::KalibroConfiguration do
     end
   end
 
-  describe 'hotspot_metric_configuartions' do
+  describe 'hotspot_metric_configurations' do
     context 'with no hotspot metric configurations' do
       before :each do
         KalibroClient::Entities::Configurations::KalibroConfiguration.
@@ -120,7 +120,7 @@ describe KalibroClient::Entities::Configurations::KalibroConfiguration do
     end
   end
 
-  describe 'tree_metric_configuartions' do
+  describe 'tree_metric_configurations' do
     context 'with no tree metric configurations' do
       before :each do
         KalibroClient::Entities::Configurations::KalibroConfiguration.


### PR DESCRIPTION
Now KalibroConfiguration instances have specific methods for retrieving just Hotspot or Tree MetricConfigurations.