### PR TITLE
Use MetricFu for acceptance tests  

### DIFF
--- a/features/metric_configuration/creation.feature
+++ b/features/metric_configuration/creation.feature
@@ -7,7 +7,7 @@ Feature: Create
   Scenario: creating a metric configuration
 	  Given I have a kalibro configuration with name "Kalibro for Java"
     And I have a reading group with name "Group"
-    When I have a loc configuration within the given kalibro configuration
+    When I have a "saikuro" configuration within the given kalibro configuration
     Then the metric configuration should exist
 
   @kalibro_configuration_restart

--- a/features/metric_configuration/destroy.feature
+++ b/features/metric_configuration/destroy.feature
@@ -7,6 +7,6 @@ Feature: Destroy
   Scenario: destroying a metric configuration
 	  Given I have a kalibro configuration with name "Kalibro for Java"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     When I destroy the metric configuration
     Then the metric configuration should no longer exist

--- a/features/metric_configuration/find.feature
+++ b/features/metric_configuration/find.feature
@@ -7,7 +7,7 @@ Feature: Find
   Scenario: find a valid metric configuration
 	  Given I have a kalibro configuration with name "Kalibro for Java"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     When I search a metric configuration with the same id of the given metric configuration
     Then it should return the same metric configuration as the given one
 

--- a/features/metric_result/metric_results_of.feature
+++ b/features/metric_result/metric_results_of.feature
@@ -6,12 +6,12 @@ Feature: Metric results of
   @kalibro_configuration_restart @kalibro_processor_restart
   Scenario: when there is a metric result
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a saikuro configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up for a ready processing
     And I call the first_processing method for the given repository

--- a/features/metric_result/metric_results_of.feature
+++ b/features/metric_result/metric_results_of.feature
@@ -8,7 +8,7 @@ Feature: Metric results of
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a saikuro configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/metric_result/module_results.feature
+++ b/features/metric_result/module_results.feature
@@ -6,12 +6,12 @@ Feature: Module Results
   @kalibro_configuration_restart @kalibro_processor_restart
   Scenario: when there is a metric result
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up for a ready processing
     And I call the first_processing method for the given repository

--- a/features/metric_result/module_results.feature
+++ b/features/metric_result/module_results.feature
@@ -8,7 +8,7 @@ Feature: Module Results
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/metric_result/tree/descendant_values.feature
+++ b/features/metric_result/tree/descendant_values.feature
@@ -8,7 +8,7 @@ Feature: Descendant values
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a saikuro configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/metric_result/tree/descendant_values.feature
+++ b/features/metric_result/tree/descendant_values.feature
@@ -6,12 +6,12 @@ Feature: Descendant values
   @kalibro_configuration_restart @kalibro_processor_restart
   Scenario: when there is a metric result
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a saikuro configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up for a ready processing
     And I call the first_processing method for the given repository

--- a/features/metric_result/tree/history_of.feature
+++ b/features/metric_result/tree/history_of.feature
@@ -6,13 +6,13 @@ Feature: history of
   @kalibro_configuration_restart @kalibro_processor_restart
   Scenario: when there is a metric result
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a metric with name "Lines of Code"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up for a ready processing
     And I call the first_processing method for the given repository

--- a/features/metric_result/tree/history_of.feature
+++ b/features/metric_result/tree/history_of.feature
@@ -8,8 +8,8 @@ Feature: history of
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a metric with name "Lines of Code"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a metric with name "Cyclomatic Complexity"
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/module_result/children.feature
+++ b/features/module_result/children.feature
@@ -6,12 +6,12 @@ Feature: Children
   @kalibro_configuration_restart @kalibro_processor_restart
   Scenario: find a valid module result
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a saikuro configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up for a ready processing
     When I ask for the children of the processing root module result

--- a/features/module_result/children.feature
+++ b/features/module_result/children.feature
@@ -8,7 +8,7 @@ Feature: Children
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a saikuro configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/module_result/find.feature
+++ b/features/module_result/find.feature
@@ -8,7 +8,7 @@ Feature: Find
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/module_result/find.feature
+++ b/features/module_result/find.feature
@@ -6,12 +6,12 @@ Feature: Find
   @kalibro_configuration_restart @kalibro_processor_restart
   Scenario: find a valid module result
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     When I call the process method for the given repository
     And I wait up for a ready processing
     And I get the module result of the processing

--- a/features/module_result/history_of.feature
+++ b/features/module_result/history_of.feature
@@ -8,7 +8,7 @@ Feature: /history of
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/module_result/history_of.feature
+++ b/features/module_result/history_of.feature
@@ -6,12 +6,12 @@ Feature: /history of
   @kalibro_configuration_restart @kalibro_processor_restart
   Scenario: get the history of a module result
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up for a ready processing
     And I get the module result of the processing

--- a/features/repository/all.feature
+++ b/features/repository/all.feature
@@ -6,10 +6,10 @@ Feature: Repositories listing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With existing project repository
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I have an independent repository
     When I ask for all the repositories
     Then the response should contain the given repositories

--- a/features/repository/cancel_processing.feature
+++ b/features/repository/cancel_processing.feature
@@ -6,9 +6,9 @@ Feature: Process
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     When I call the cancel_process method for the given repository
     Then I should get success

--- a/features/repository/destroy.feature
+++ b/features/repository/destroy.feature
@@ -6,9 +6,9 @@ Feature: Repositories destroying
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With existing repository
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     When I destroy the repository
     Then the repository should no longer exist

--- a/features/repository/exists.feature
+++ b/features/repository/exists.feature
@@ -6,9 +6,9 @@ Feature: Repositories listing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With existing project repository
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     When I ask to check if the given repository exists
     Then I should get true

--- a/features/repository/find.feature
+++ b/features/repository/find.feature
@@ -6,9 +6,9 @@ Feature: Repositories listing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With existing project repository
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     When I ask to find the given repository
     Then I should get the given repository

--- a/features/repository/of.feature
+++ b/features/repository/of.feature
@@ -6,10 +6,10 @@ Feature: Repositories listing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With existing project repository
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     When I ask for repositories from the given project
     Then I should get a list with the given repository
     And the repositories should contain the project id

--- a/features/repository/process.feature
+++ b/features/repository/process.feature
@@ -6,11 +6,11 @@ Feature: Process
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     When I call the process method for the given repository
     Then I should get success

--- a/features/repository/process.feature
+++ b/features/repository/process.feature
@@ -8,7 +8,7 @@ Feature: Process
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                   address                        |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/first_processing.feature
+++ b/features/repository/processing/first_processing.feature
@@ -6,12 +6,12 @@ Feature: First processing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the first_processing method for the given repository

--- a/features/repository/processing/first_processing.feature
+++ b/features/repository/processing/first_processing.feature
@@ -8,7 +8,7 @@ Feature: First processing
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/first_processing_after.feature
+++ b/features/repository/processing/first_processing_after.feature
@@ -8,7 +8,7 @@ Feature: First processing after
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/first_processing_after.feature
+++ b/features/repository/processing/first_processing_after.feature
@@ -6,12 +6,12 @@ Feature: First processing after
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the first_processing_after method for the given repository and yesterday's date

--- a/features/repository/processing/has_processing.feature
+++ b/features/repository/processing/has_processing.feature
@@ -6,12 +6,12 @@ Feature: Has processing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository after process
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the has_processing for the given repository

--- a/features/repository/processing/has_processing.feature
+++ b/features/repository/processing/has_processing.feature
@@ -8,7 +8,7 @@ Feature: Has processing
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/has_processing_after.feature
+++ b/features/repository/processing/has_processing_after.feature
@@ -8,7 +8,7 @@ Feature: Has processing after
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/has_processing_after.feature
+++ b/features/repository/processing/has_processing_after.feature
@@ -6,12 +6,12 @@ Feature: Has processing after
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the has_processing_after for the given repository with yerterday's date

--- a/features/repository/processing/has_processing_before.feature
+++ b/features/repository/processing/has_processing_before.feature
@@ -8,7 +8,7 @@ Feature: Has processing before
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/has_processing_before.feature
+++ b/features/repository/processing/has_processing_before.feature
@@ -6,12 +6,12 @@ Feature: Has processing before
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the has_processing_before for the given repository with tomorrows's date

--- a/features/repository/processing/has_ready_processing.feature
+++ b/features/repository/processing/has_ready_processing.feature
@@ -8,7 +8,7 @@ Feature: Has ready processing
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/has_ready_processing.feature
+++ b/features/repository/processing/has_ready_processing.feature
@@ -6,12 +6,12 @@ Feature: Has ready processing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the has_ready_processing for the given repository

--- a/features/repository/processing/last_processing.feature
+++ b/features/repository/processing/last_processing.feature
@@ -8,7 +8,7 @@ Feature: Last processing
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/last_processing.feature
+++ b/features/repository/processing/last_processing.feature
@@ -6,12 +6,12 @@ Feature: Last processing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the last_processing method for the given repository

--- a/features/repository/processing/last_processing_before.feature
+++ b/features/repository/processing/last_processing_before.feature
@@ -6,12 +6,12 @@ Feature: Last processing before
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the last_processing_before method for the given repository and tomorrow's date

--- a/features/repository/processing/last_processing_before.feature
+++ b/features/repository/processing/last_processing_before.feature
@@ -8,7 +8,7 @@ Feature: Last processing before
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/last_processing_state.feature
+++ b/features/repository/processing/last_processing_state.feature
@@ -6,12 +6,12 @@ Feature: Last processing state
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the last_processing_state method for the given repository

--- a/features/repository/processing/last_processing_state.feature
+++ b/features/repository/processing/last_processing_state.feature
@@ -8,7 +8,7 @@ Feature: Last processing state
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/last_ready_processing.feature
+++ b/features/repository/processing/last_ready_processing.feature
@@ -8,7 +8,7 @@ Feature: Last ready processing
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/last_ready_processing.feature
+++ b/features/repository/processing/last_ready_processing.feature
@@ -6,12 +6,12 @@ Feature: Last ready processing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after with ready processing
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up for a ready processing
     When I call the last_ready_processing method for the given repository

--- a/features/repository/processing/processing.feature
+++ b/features/repository/processing/processing.feature
@@ -8,7 +8,7 @@ Feature: Processing
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
@@ -22,7 +22,7 @@ Feature: Processing
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/processing.feature
+++ b/features/repository/processing/processing.feature
@@ -6,12 +6,12 @@ Feature: Processing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the processing method for the given repository
@@ -20,12 +20,12 @@ Feature: Processing
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after with ready processing
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up for a ready processing
     When I call the processing method for the given repository

--- a/features/repository/processing/processing_with_date.feature
+++ b/features/repository/processing/processing_with_date.feature
@@ -8,7 +8,7 @@ Feature: Processing with date
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
@@ -22,7 +22,7 @@ Feature: Processing with date
     Given I have a project with name "Kalibro"
     And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
       |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |

--- a/features/repository/processing/processing_with_date.feature
+++ b/features/repository/processing/processing_with_date.feature
@@ -6,12 +6,12 @@ Feature: Processing with date
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process and tomorrow's date
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the processing_with_date method for the given repository and tomorrow's date
@@ -20,12 +20,12 @@ Feature: Processing with date
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after starting to process and yesterday's date
     Given I have a project with name "Kalibro"
-    And I have a kalibro configuration with name "Java"
+    And I have a kalibro configuration with name "Conf"
     And I have a reading group with name "Group"
     And I have a loc configuration within the given kalibro configuration
     And the given project has the following Repositories:
       |   name    | scm_type |                       address                    |
-      |  Kalibro  |    GIT   | https://github.com/rafamanzo/runge-kutta-vtk.git |
+      |  Kalibro  |    GIT   | https://github.com/mezuro/kalibro_processor.git  |
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the processing_with_date method for the given repository and yesterday's date

--- a/features/statistic/metric_percentage.feature
+++ b/features/statistic/metric_percentage.feature
@@ -8,6 +8,6 @@ Feature: Calculating the percentage of metrics used
     Given I have a kalibro configuration with name "Java"
     And I have a reading group with name "Group"
     And I have a metric with name "Lines of Code"
-    And I have a loc configuration within the given kalibro configuration
+    And I have a "saikuro" configuration within the given kalibro configuration
     When I request the metric_percentage
     Then I should get a hash containing a real number

--- a/features/step_definitions/metric_configuration_steps.rb
+++ b/features/step_definitions/metric_configuration_steps.rb
@@ -1,7 +1,7 @@
 Given(/^I have a metric configuration within the given kalibro configuration$/) do
   @metric_configuration = FactoryGirl.create(:metric_configuration,
-                                             {reading_group_id: @reading_group.id,
-                                              kalibro_configuration_id: @kalibro_configuration.id})
+                                             reading_group_id: @reading_group.id,
+                                             kalibro_configuration_id: @kalibro_configuration.id)
 end
 
 Given(/^I have a metric configuration within the given kalibro configuration with the given metric$/) do
@@ -11,11 +11,11 @@ Given(/^I have a metric configuration within the given kalibro configuration wit
                                               kalibro_configuration_id: @kalibro_configuration.id})
 end
 
-Given(/^I have a loc configuration within the given kalibro configuration$/) do
+Given(/^I have a (.+) configuration within the given kalibro configuration$/) do |metric_code|
   @metric_configuration = FactoryGirl.create(:metric_configuration,
-                                             {metric: FactoryGirl.build(:loc),
-                                              reading_group_id: @reading_group.id,
-                                              kalibro_configuration_id: @kalibro_configuration.id})
+                                             metric: FactoryGirl.build(metric_code.to_sym),
+                                             reading_group_id: @reading_group.id,
+                                             kalibro_configuration_id: @kalibro_configuration.id)
 end
 
 Given(/^I have a hotspot metric configuration within the given kalibro configuration$/) do

--- a/features/step_definitions/metric_configuration_steps.rb
+++ b/features/step_definitions/metric_configuration_steps.rb
@@ -11,7 +11,7 @@ Given(/^I have a metric configuration within the given kalibro configuration wit
                                               kalibro_configuration_id: @kalibro_configuration.id})
 end
 
-Given(/^I have a (.+) configuration within the given kalibro configuration$/) do |metric_code|
+Given(/^I have a "(.+)" configuration within the given kalibro configuration$/) do |metric_code|
   @metric_configuration = FactoryGirl.create(:metric_configuration,
                                              metric: FactoryGirl.build(metric_code.to_sym),
                                              reading_group_id: @reading_group.id,
@@ -25,7 +25,7 @@ Given(/^I have a hotspot metric configuration within the given kalibro configura
 end
 
 Given(/^I have a tree metric configuration within the given kalibro configuration$/) do
-  step "I have a loc configuration within the given kalibro configuration"
+  step 'I have a "saikuro" configuration within the given kalibro configuration'
   @tree_metric_configuration = @metric_configuration
 end
 

--- a/spec/factories/metrics.rb
+++ b/spec/factories/metrics.rb
@@ -55,4 +55,15 @@ FactoryGirl.define do
 
     initialize_with { KalibroClient::Entities::Miscellaneous::HotspotMetric.new(name, code, languages, metric_collector_name) }
   end
+
+  factory :saikuro, class: KalibroClient::Entities::Miscellaneous::NativeMetric do
+    name 'Cyclomatic Complexity'
+    code 'saikuro'
+    scope 'METHOD'
+    description ''
+    metric_collector_name 'MetricFu'
+    languages nil
+
+    initialize_with { KalibroClient::Entities::Miscellaneous::NativeMetric.new(name, code, scope, languages, metric_collector_name) }
+  end
 end


### PR DESCRIPTION
After https://github.com/mezuro/kalibro_client_py/pull/64 the features that need to process a repository should use a MetricFu metric to avoid travis to hang on the `collecting` step.