### PR TITLE
Fix acceptance tests that depend on a processing state

### DIFF
--- a/features/repository/processing/last_processing_state.feature
+++ b/features/repository/processing/last_processing_state.feature
@@ -15,4 +15,4 @@ Feature: Last processing state
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the last_processing_state method for the given repository
-    Then I should get "PREPARING"
+    Then I should get a valid state

--- a/features/repository/processing/processing.feature
+++ b/features/repository/processing/processing.feature
@@ -15,7 +15,7 @@ Feature: Processing
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the processing method for the given repository
-    Then I should get a Processing with state "PREPARING"
+    Then I should get a Processing
 
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: With one repository just after with ready processing

--- a/features/step_definitions/processing_steps.rb
+++ b/features/step_definitions/processing_steps.rb
@@ -76,6 +76,13 @@ Then(/^I should get "(.*?)"$/) do |state|
   expect(@response).to eq(state)
 end
 
+Then(/^I should get a valid state$/) do
+  # REFACTOR ME: maybe the list of valid states should be retrieved from the Processor
+  states = ["PREPARING", "DOWNLOADING", "COLLECTING",
+            "CHECKING", "BUILDING", "AGGREGATING", "CALCULATING", "INTERPRETING"]
+  expect(states).to include(@response)
+end
+
 Then(/^I should get false$/) do
   expect(@response).to be_falsey
 end


### PR DESCRIPTION
That kind of tests are highly dependent on the machine running the
tests. That caused Travis to fail too frequently.
Now, instead of checking for a specific state, we check if a state is
valid or if we can retrieve a Processing.

Signed off by: Heitor Reis <marcheing@gmail.com>