### PR TITLE
Relax faraday_middleware version requirement

### DIFF
--- a/kalibro_client.gemspec
+++ b/kalibro_client.gemspec
@@ -46,5 +46,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ruby-prof"
 
   spec.add_dependency "activesupport", ">= 2.2.1" #version in which underscore was introduced
-  spec.add_dependency "faraday_middleware", "~> 0.10.0"
+  spec.add_dependency "faraday_middleware", "~> 0.9"
 end


### PR DESCRIPTION
In order to improve compatibility with other gems while bundling
(codeclimate) it requires any minor updater greater or equal than 0.9.