### PR TITLE
Enable code coverage check

### DIFF
--- a/spec/kalibro_cucumber_helpers/kalibro_cucumber_helper_spec.rb
+++ b/spec/kalibro_cucumber_helpers/kalibro_cucumber_helper_spec.rb
@@ -1,0 +1,29 @@
+require 'rspec/mocks'
+require 'faraday'
+require 'likeno'
+require 'kalibro_client/kalibro_cucumber_helpers'
+
+describe KalibroClient::KalibroCucumberHelpers do
+  let(:cleaner) { mock("KalibroClient::KalibroCucumberHelpers::Cleaner") }
+
+  describe 'methods' do
+      let(:processor_cleaner) { mock("KalibroClient::KalibroCucumberHelpers::Cleaner") }
+
+      before :each do
+        KalibroClient::KalibroCucumberHelpers::Cleaner.expects(:new).returns(cleaner)
+        cleaner.expects(:clean_database)
+      end
+
+      describe 'clean_processor' do
+        it 'is expected to clean the processor database' do
+          KalibroClient::KalibroCucumberHelpers.clean_processor
+      end
+
+      describe 'clean_configurations' do
+        it 'is expected to clean the processor database' do
+          KalibroClient::KalibroCucumberHelpers.clean_configurations
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,11 @@ SimpleCov.start do
   add_filter "/features/"
 
   coverage_dir 'coverage/rspec'
+
+  # Minimum coverage is only desired on CI tools when building the environment. CI is a
+  # default environment variable used by Travis. For reference, see here:
+  # https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+  minimum_coverage 100 if ENV["CI"] == 'true'
 end
 
 require 'kalibro_client'


### PR DESCRIPTION
With this, our continuous integration tests will fail without full code coverage.