### PR TITLE
Adapt gemspec to old rubies and activesupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The Kalibro Client gem abstracts communication with all the services in the Mezuro
 platform, with an uniform Ruby API.
 
+## Unreleased
+ - Handle activesupport >= 5.0.0 incompatbility
+
 ## v4.0.0 - 30/03/2016
 - Extract HTTP request handling code to the Likeno gem (https://github.com/mezuro/likeno)
 - Refactor MetricCollector and MetricCollectoDetails finding methods

--- a/kalibro_client.gemspec
+++ b/kalibro_client.gemspec
@@ -45,7 +45,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "ruby-prof"
 
-  spec.add_dependency "activesupport", ">= 2.2.1" #version in which underscore was introduced
+  if RUBY_VERSION < '2.2.2'
+    spec.add_dependency "activesupport", ">= 2.2.1", "< 5" #versions in which underscore was introduced and earlier rubies were no longer supported
+  else
+    spec.add_dependency "activesupport", ">= 2.2.1" #version in which underscore was introduced
+  end
   spec.add_dependency "faraday_middleware", "~> 0.9"
   spec.add_dependency "likeno", "~> 1.1"
 end


### PR DESCRIPTION
From version 5.0.0 it no longer supports rubies below 2.2.2. But those
old activesupport versions are still working here.