### PR TITLE
Fix older ruby version compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The Kalibro Client gem abstracts communication with all the services in the Mezuro
 platform, with an uniform Ruby API.
 
+## Unreleased
+
+- Drop ActiveSupport >= 5.0 support
+
 ## v4.0.0 - 30/03/2016
 - Extract HTTP request handling code to the Likeno gem (https://github.com/mezuro/likeno)
 - Refactor MetricCollector and MetricCollectoDetails finding methods

--- a/kalibro_client.gemspec
+++ b/kalibro_client.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "ruby-prof"
 
-  spec.add_dependency "activesupport", ">= 2.2.1" #version in which underscore was introduced
+  spec.add_dependency "activesupport", ">= 2.2.1", "< 5" # 2.2.1 is the version in which underscore was introduced. Version 5 drops older rubies support
   spec.add_dependency "faraday_middleware", "~> 0.9"
   spec.add_dependency "likeno", "~> 1.1"
 end


### PR DESCRIPTION
It would install an unsupported activesupport version. Now we prevent
that.

Please notice the merge target is a specific maintenance branch for version 4.