### PR TITLE
Stop building against older rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
   - 2.3.0
-  - 2.0.0-p598 # CentOS 7
-  - 2.1.5 # Debian 8
 
 addons:
   postgresql: "9.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The Kalibro Client gem abstracts communication with all the services in the Mezuro
 platform, with an uniform Ruby API.
 
+## Unreleased
+- Drop Ruby 2.0.0 and 2.1.5 support
+
 ## v4.0.0 - 30/03/2016
 - Extract HTTP request handling code to the Likeno gem (https://github.com/mezuro/likeno)
 - Refactor MetricCollector and MetricCollectoDetails finding methods

--- a/kalibro_client.gemspec
+++ b/kalibro_client.gemspec
@@ -35,6 +35,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.2.2'
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
They are no longer supported by Rails, thus this next version will as
well.